### PR TITLE
Bump numactl to v2.0.19

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -36,8 +36,8 @@
     		"sources": [
     			{
     				"type": "archive",
-    				"url": "https://github.com/numactl/numactl/releases/download/v2.0.18/numactl-2.0.18.tar.gz",
-    				"sha256": "b4fc0956317680579992d7815bc43d0538960dc73aa1dd8ca7e3806e30bc1274"
+    				"url": "https://github.com/numactl/numactl/releases/download/v2.0.19/numactl-2.0.19.tar.gz",
+    				"sha256": "f2672a0381cb59196e9c246bf8bcc43d5568bc457700a697f1a1df762b9af884"
     			}
     		]
     	},


### PR DESCRIPTION
Unsure how it's being used with Alpaca, but seemed like a small bug fix. If unneeded, can be ignored.