### PR TITLE
Bump Ollama-ROCm Metadata

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,6 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
+    <release version="0.12.0" date="2025-09-18"/>
     <release version="0.11.10" date="2025-09-05"/>
     <release version="0.11.3" date="2025-08-06"/>
     <release version="0.9.3" date="2025-06-26"/>


### PR DESCRIPTION
Updated metadata to reflect the Ollama-ROCm release on 2025-09-18.

Related to https://github.com/Jeffser/Alpaca/issues/1004