### PR TITLE
Update Ollama AMD ROCm build (+metadata) and code formatting update

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -1,58 +1,54 @@
 {
-    "id": "com.jeffser.Alpaca.Plugins.AMD",
-    "runtime": "com.jeffser.Alpaca",
-    "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//49",
-    "build-extension": true,
-    "cleanup": [
-        "*.a",
-        "*.la"
-    ],
-    "modules": [
+  "id": "com.jeffser.Alpaca.Plugins.AMD",
+  "runtime": "com.jeffser.Alpaca",
+  "runtime-version": "stable",
+  "sdk": "org.gnome.Sdk//49",
+  "build-extension": true,
+  "cleanup": [
+    "*.a",
+    "*.la"
+  ],
+  "modules": [
+    {
+      "name": "rocm",
+      "buildsystem": "simple",
+      "build-commands": ["cp -rf --remove-destination ./* ${FLATPAK_DEST}/"],
+      "sources": [
         {
-            "name": "rocm",
-            "buildsystem": "simple",
-            "build-commands": [
-            	"cp -rf --remove-destination ./* ${FLATPAK_DEST}/"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/ollama/ollama/releases/download/v0.12.6/ollama-linux-amd64-rocm.tgz",
-                    "sha256": "65461aa6550e1078471983245bfc24cce1c2bda6698b190ec36e1884aa3a02de",
-                    "strip-components": 0
-                }
-            ]
-        },
-        {
-    		"name": "libnuma",
-    		"buildsystem": "autotools",
-    		"build-commands": [
-    			"autoreconf -i",
-    			"./configure --prefix=${FLATPAK_DEST}",
-    			"make",
-    			"make install"
-    		],
-    		"sources": [
-    			{
-    				"type": "archive",
-    				"url": "https://github.com/numactl/numactl/releases/download/v2.0.19/numactl-2.0.19.tar.gz",
-    				"sha256": "f2672a0381cb59196e9c246bf8bcc43d5568bc457700a697f1a1df762b9af884"
-    			}
-    		]
-    	},
-        {
-            "name": "metainfo",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install -Dm0644 com.jeffser.Alpaca.Plugins.AMD.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "path": "com.jeffser.Alpaca.Plugins.AMD.metainfo.xml"
-                }
-            ]
+          "type": "archive",
+          "url": "https://github.com/ollama/ollama/releases/download/v0.12.10/ollama-linux-amd64-rocm.tgz",
+          "sha256": "c9cf58a7e95d76400448c7d0cc25844da337e63569a14b73bd6e7a160d3e22de",
+          "strip-components": 0
         }
-    ]
+      ]
+    },
+    {
+      "name": "libnuma",
+      "buildsystem": "autotools",
+      "build-commands": [
+        "autoreconf -i",
+        "./configure --prefix=${FLATPAK_DEST}",
+        "make",
+        "make install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/numactl/numactl/releases/download/v2.0.19/numactl-2.0.19.tar.gz",
+          "sha256": "f2672a0381cb59196e9c246bf8bcc43d5568bc457700a697f1a1df762b9af884"
+        }
+      ]
+    },
+    {
+      "name": "metainfo",
+      "buildsystem": "simple",
+      "build-commands": ["install -Dm0644 com.jeffser.Alpaca.Plugins.AMD.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"],
+      "sources": [
+        {
+          "type": "file",
+          "path": "com.jeffser.Alpaca.Plugins.AMD.metainfo.xml"
+        }
+      ]
+    }
+  ]
 }

--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,6 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
+    <release version="0.12.10" date="2025-11-05"/>
     <release version="0.12.6" date="2025-10-25"/>
     <release version="0.12.0" date="2025-09-18"/>
     <release version="0.11.10" date="2025-09-05"/>


### PR DESCRIPTION
Update Ollama AMD ROCm build (+metadata) and code formatting update.

Cleaned up code formatting as I plan on regularly submitting PRs when Ollama releases a new version.

The code reformat uses your pre-existing GNU style formatting but with mixed usage of spaces & tabs cleaned up into a uniform two-spaces style, as well as condensing some arrays which can be condensed down to single line arrays since they only encompass one value.