### PR TITLE
Update Ollama ROCm Runtime to v0.13.0

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -16,8 +16,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/ollama/ollama/releases/download/v0.12.10/ollama-linux-amd64-rocm.tgz",
-          "sha256": "c9cf58a7e95d76400448c7d0cc25844da337e63569a14b73bd6e7a160d3e22de",
+          "url": "https://github.com/ollama/ollama/releases/download/v0.13.0/ollama-linux-amd64-rocm.tgz",
+          "sha256": "d9e86eab27819394c7c874af041eea7a31255b37510f908a94b7f3cf7328db2a",
           "strip-components": 0
         }
       ]

--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,6 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
+    <release version="0.13.0" date="2025-11-19"/>
     <release version="0.12.10" date="2025-11-05"/>
     <release version="0.12.6" date="2025-10-25"/>
     <release version="0.12.0" date="2025-09-18"/>


### PR DESCRIPTION
Updates the Ollama ROCm runtime to v0.13.0 which features the following updates as listed here:

https://github.com/ollama/ollama/releases/tag/v0.13.0