### PR TITLE
Update Ollama ROCm Runtime to v0.13.1

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -16,8 +16,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/ollama/ollama/releases/download/v0.13.0/ollama-linux-amd64-rocm.tgz",
-          "sha256": "d9e86eab27819394c7c874af041eea7a31255b37510f908a94b7f3cf7328db2a",
+          "url": "https://github.com/ollama/ollama/releases/download/v0.13.1/ollama-linux-amd64-rocm.tgz",
+          "sha256": "614e78776e76ff28d8b9305d09cd81638241c6e2ae546891f4a76d100ed1e746",
           "strip-components": 0
         }
       ]

--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -16,8 +16,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/ollama/ollama/releases/download/v0.13.1/ollama-linux-amd64-rocm.tgz",
-          "sha256": "614e78776e76ff28d8b9305d09cd81638241c6e2ae546891f4a76d100ed1e746",
+          "url": "https://github.com/ollama/ollama/releases/download/v0.13.2/ollama-linux-amd64-rocm.tgz",
+          "sha256": "45e1934c1439df5029f046250625deddacf00dceb9f873c44992b8f8ab2d97b5",
           "strip-components": 0
         }
       ]

--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,7 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
-    <release version="0.13.1" date="2025-11-26"/>
+    <release version="0.13.2" date="2025-12-03"/>
     <release version="0.13.0" date="2025-11-19"/>
     <release version="0.12.10" date="2025-11-05"/>
     <release version="0.12.6" date="2025-10-25"/>

--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,6 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
+    <release version="0.13.1" date="2025-11-26"/>
     <release version="0.13.0" date="2025-11-19"/>
     <release version="0.12.10" date="2025-11-05"/>
     <release version="0.12.6" date="2025-10-25"/>


### PR DESCRIPTION
Updates the Ollama ROCm runtime/program to v0.13.1, which features the following updates as listed here:

https://github.com/ollama/ollama/releases/tag/v0.13.1