### PR TITLE
Update to Ollama ROCm v0.15.1

### DIFF
--- a/com.jeffser.Alpaca.Plugins.AMD.json
+++ b/com.jeffser.Alpaca.Plugins.AMD.json
@@ -16,8 +16,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/ollama/ollama/releases/download/v0.13.2/ollama-linux-amd64-rocm.tgz",
-          "sha256": "45e1934c1439df5029f046250625deddacf00dceb9f873c44992b8f8ab2d97b5",
+          "url": "https://github.com/ollama/ollama/releases/download/v0.15.1/ollama-linux-amd64-rocm.tar.zst",
+          "sha256": "ebe6cb8c032525c8292b77369827d3880087cd71172087e8788d3d6918abd282",
           "strip-components": 0
         }
       ]

--- a/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.AMD.metainfo.xml
@@ -21,6 +21,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
+    <release version="0.15.1" date="2026-01-25"/>
     <release version="0.13.2" date="2025-12-11"/>
     <release version="0.13.0" date="2025-11-19"/>
     <release version="0.12.10" date="2025-11-05"/>


### PR DESCRIPTION
This PR will add two commits that update the plug-in to the latest (as of this writing) version of  `ollama-rocm`  which is `0.15.1`:  https://github.com/ollama/ollama/releases/tag/v0.15.1

